### PR TITLE
refactor(deploy): Configure Docker Compose to use Docker Hub images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,7 @@ services:
       retries: 5
 
   backend:
-    build:
-      context: ./prueba-tecnica-sysman-backend
-      dockerfile: Dockerfile
+    image: rogueanovi/prueba-tecnica-sysman-backend:1.0.0
     container_name: sysman-backend
     restart: on-failure
     depends_on:
@@ -41,9 +39,7 @@ services:
       - sysman-network
 
   frontend:
-    build:
-      context: ./prueba-tecnica-sysman-frontend
-      dockerfile: Dockerfile
+    image: rogueanovi/prueba-tecnica-sysman-frontend:1.0.0
     container_name: sysman-frontend
     restart: on-failure
     ports:


### PR DESCRIPTION
Updates docker-compose.yml to pull pre-built images from Docker Hub instead of building them locally. This simplifies deployment and improves portability.